### PR TITLE
Accept user input for park prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.idea
 /newparks_cache.sqlite
-/newparks.kml
+/newparks*.kml
 /parksbylastactivated_cache.sqlite
 /parksbylastactivated.kml

--- a/newparks.py
+++ b/newparks.py
@@ -9,41 +9,50 @@ from requests_cache import CachedSession
 from datetime import timedelta
 import simplekml
 
-# Ensure user provided a prefix
-if len(sys.argv) != 2:
-    print("Usage: python newparks.py <programPrefix>")
-    sys.exit(1)
-
-input_prefix = sys.argv[1].upper()
-
-# Create KML object to fill with unactivated parks
+# Setup cache and KML
+session = CachedSession("newparks_cache", expire_after=timedelta(days=1))
 kml = simplekml.Kml()
 
 # Fetch list of programs
-session = CachedSession("newparks_cache", expire_after=timedelta(days=1))
 programs = session.get("https://api.pota.app/programs").json()
-
-# Validate the input prefix
 valid_prefixes = {program["programPrefix"]: program for program in programs}
-if input_prefix not in valid_prefixes:
-    print(f"Invalid programPrefix '{input_prefix}'. Valid options are: {', '.join(valid_prefixes.keys())}")
-    sys.exit(1)
 
-print(f"Fetching parks for program prefix: {input_prefix}")
+# Check command-line arguments
+args = sys.argv[1:]
 
-# Fetch parks for the specified prefix
-parks = session.get(f"https://api.pota.app/program/parks/{input_prefix}").json()
-print(f"Found {len(parks)} parks in {input_prefix}")
+# Option to list all valid prefixes
+if args and args[0] == "--list":
+    print("Valid program prefixes:")
+    for prefix in sorted(valid_prefixes.keys()):
+        print(f"  {prefix}")
+    sys.exit(0)
 
-# Add unactivated parks to KML
-for park in parks:
-    if park["activations"] == 0:
-        kml.newpoint(name=f'{park["reference"]} {park["name"]}',
-                     description=f'https://pota.app/#/park/{park["reference"]}',
-                     coords=[(park["longitude"], park["latitude"])])
+# Function to add unactivated parks for a prefix
+def add_unactivated_parks(prefix):
+    parks = session.get(f"https://api.pota.app/program/parks/{prefix}").json()
+    print(f"Found {len(parks)} parks in {prefix}")
+    for park in parks:
+        if park["activations"] == 0:
+            kml.newpoint(name=f'{park["reference"]} {park["name"]}',
+                         description=f'https://pota.app/#/park/{park["reference"]}',
+                         coords=[(park["longitude"], park["latitude"])])
 
-# Save KML
-filename = f"newparks-{input_prefix}.kml"
+# If a specific prefix is provided
+if args:
+    prefix = args[0].upper()
+    if prefix not in valid_prefixes:
+        print(f"Invalid programPrefix '{prefix}'. Use --list to see valid options.")
+        sys.exit(1)
+    print(f"Fetching parks for program prefix: {prefix}")
+    add_unactivated_parks(prefix)
+    filename = f"newparks-{prefix}.kml"
+else:
+    print("No prefix provided. Fetching parks for all programs...")
+    for prefix in valid_prefixes:
+        add_unactivated_parks(prefix)
+    filename = "newparks.kml"
+
+# Save KML file
 print(f"Writing to {filename}...")
 kml.save(filename)
 print("Done.")

--- a/newparks.py
+++ b/newparks.py
@@ -4,9 +4,17 @@
 # See the README.md file for more details.
 # This is Public Domain software, see the LICENCE file
 
+import sys
 from requests_cache import CachedSession
 from datetime import timedelta
 import simplekml
+
+# Ensure user provided a prefix
+if len(sys.argv) != 2:
+    print("Usage: python newparks.py <programPrefix>")
+    sys.exit(1)
+
+input_prefix = sys.argv[1].upper()
 
 # Create KML object to fill with unactivated parks
 kml = simplekml.Kml()
@@ -14,22 +22,28 @@ kml = simplekml.Kml()
 # Fetch list of programs
 session = CachedSession("newparks_cache", expire_after=timedelta(days=1))
 programs = session.get("https://api.pota.app/programs").json()
-print("Found " + str(len(programs)) + " POTA programs")
 
-# For each program, fetch a list of parks
-for program in programs:
-    prefix = program["programPrefix"]
-    parks = session.get("https://api.pota.app/program/parks/" + prefix).json()
-    print("Found " + str(len(parks)) + " parks in " + prefix)
+# Validate the input prefix
+valid_prefixes = {program["programPrefix"]: program for program in programs}
+if input_prefix not in valid_prefixes:
+    print(f"Invalid programPrefix '{input_prefix}'. Valid options are: {', '.join(valid_prefixes.keys())}")
+    sys.exit(1)
 
-    # For each park, if it's not activated, store its details in the KML
-    for park in parks:
-        if park["activations"] == 0:
-            kml.newpoint(name=park["reference"] + " " + park["name"],
-                         description="https://pota.app/#/park/" + park["reference"],
-                         coords=[(park["longitude"], park["latitude"])])
+print(f"Fetching parks for program prefix: {input_prefix}")
+
+# Fetch parks for the specified prefix
+parks = session.get(f"https://api.pota.app/program/parks/{input_prefix}").json()
+print(f"Found {len(parks)} parks in {input_prefix}")
+
+# Add unactivated parks to KML
+for park in parks:
+    if park["activations"] == 0:
+        kml.newpoint(name=f'{park["reference"]} {park["name"]}',
+                     description=f'https://pota.app/#/park/{park["reference"]}',
+                     coords=[(park["longitude"], park["latitude"])])
 
 # Save KML
-print("Writing to newparks.kml...")
-kml.save("newparks.kml")
+filename = f"newparks-{input_prefix}.kml"
+print(f"Writing to {filename}...")
+kml.save(filename)
 print("Done.")


### PR DESCRIPTION
As per my issue #1, here's an update to the script to accept a specific prefix and get the data just for that country.

Also added a `--list` option to list them and retain the original functionality if no prefix is provided.